### PR TITLE
fix: Add engine node to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "dev": "nodemon src/server.ts",
     "test": "jest"
   },
+  "engines": {
+    "node": ">=12.3.1"
+  },
   "devDependencies": {
     "@shelf/jest-mongodb": "^1.1.3",
     "@types/express": "^4.17.2",


### PR DESCRIPTION
In some tests is being used the function Readable.from, but it was implemented after node 12.3.

Then I added the node engine in package.json to prevent users to install and run the project with a lower version of node that will not work.