### PR TITLE
Fix duplicated tags received error

### DIFF
--- a/src/services/ImportContactsService.spec.ts
+++ b/src/services/ImportContactsService.spec.ts
@@ -118,4 +118,26 @@ describe('Import', () => {
       expect.objectContaining({ title: 'Class A' }),
     ]);
   });
+
+
+  it('should ignore duplicate tags received', async () => {
+    const contactsFileStream = Readable.from([
+      'diego@rocketseat.com.br\n',
+      'robson@rocketseat.com.br\n',
+      'cleiton@rocketseat.com.br\n',
+    ]);
+
+    const importContacts = new ImportContactsService();
+
+    await importContacts.run(contactsFileStream, ['Students', 'Class A', 'Class A']);
+
+    const createdTags = await Tag.find({}).lean();
+
+    expect(createdTags).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ title: 'Students' }),
+        expect.objectContaining({ title: 'Class A' }),
+      ]),
+    );
+  });
 });

--- a/src/services/ImportContactsService.ts
+++ b/src/services/ImportContactsService.ts
@@ -12,16 +12,17 @@ class ImportContactsService {
 
     const parseCSV = contactsFileStream.pipe(parsers);
 
+    const uniqueTags = tags.filter((tag, index) => tags.indexOf(tag) === index);
     const existentTags = await Tag.find({
       title: {
-        $in: tags,
+        $in: uniqueTags,
       },
     });
 
     const existentTagsTitles = existentTags.map(tag => tag.title);
     const existentTagsIds = existentTags.map(tag => tag._id);
 
-    const newTagsData = tags
+    const newTagsData = uniqueTags
       .filter(tag => !existentTagsTitles.includes(tag))
       .map(tag => ({ title: tag }));
 


### PR DESCRIPTION
Sending an array with duplicate tags causes an error in mongodb.

This was resolved by making the list of tag names unique.